### PR TITLE
Improve root directory detection with MSBuild-based approach

### DIFF
--- a/Sourcy.Core/Sourcy.Core.csproj
+++ b/Sourcy.Core/Sourcy.Core.csproj
@@ -6,4 +6,9 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
+    <!-- Include props file in NuGet package for MSBuild-based root detection -->
+    <ItemGroup>
+        <None Include="build\**\*" Pack="true" PackagePath="build" />
+    </ItemGroup>
+
 </Project>

--- a/Sourcy.Core/build/Sourcy.Core.props
+++ b/Sourcy.Core/build/Sourcy.Core.props
@@ -1,0 +1,30 @@
+<Project>
+  <!--
+    Sourcy Root Detection
+    =====================
+    This props file uses MSBuild's GetDirectoryNameOfFileAbove to find the repository root
+    at MSBuild evaluation time, which is more reliable than walking the directory tree
+    at source generator execution time.
+
+    Priority order:
+    1. .sourcyroot (explicit marker file - highest priority)
+    2. .git (standard git repository marker)
+    3. Directory.Build.props (MSBuild convention)
+    4. global.json (.NET SDK convention)
+
+    Users can override by setting SourcyRootPath explicitly in their project file.
+  -->
+
+  <PropertyGroup>
+    <!-- Only compute if not already set by user -->
+    <SourcyRootPath Condition="'$(SourcyRootPath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '.sourcyroot'))</SourcyRootPath>
+    <SourcyRootPath Condition="'$(SourcyRootPath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '.git'))</SourcyRootPath>
+    <SourcyRootPath Condition="'$(SourcyRootPath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.props'))</SourcyRootPath>
+    <SourcyRootPath Condition="'$(SourcyRootPath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'global.json'))</SourcyRootPath>
+  </PropertyGroup>
+
+  <!-- Make SourcyRootPath visible to source generators via AnalyzerConfigOptionsProvider -->
+  <ItemGroup>
+    <CompilerVisibleProperty Include="SourcyRootPath" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

- Add `Sourcy.Core.props` using MSBuild's `GetDirectoryNameOfFileAbove()` for faster, more reliable root detection at MSBuild evaluation time
- Add `Directory.Build.props` and `global.json` as additional fallback markers in the C# code
- Prioritize `.sourcyroot` over `.git` for explicit marker files (user-requested change)
- Improve git worktree/submodule detection with better documentation
- Add static cache (`ConcurrentDictionary`) for root directory lookups to avoid repeated file system traversals when multiple generators run for the same project
- Document the `SourcyRootPath` custom override property in CLAUDE.md

## Root Detection Priority

The new two-tier approach:

**Tier 1 (MSBuild-based - preferred):**
1. `.sourcyroot` - Explicit marker file (highest priority)
2. `.git` - Standard git repository
3. `Directory.Build.props` - MSBuild convention
4. `global.json` - .NET SDK convention

**Tier 2 (C# fallback):**
Same markers, checked if MSBuild detection fails. Results are cached to avoid repeated file system traversals.

## Test plan

- [x] Build succeeds with no errors
- [x] All 22 existing tests pass
- [x] Props file included in NuGet package at `build/Sourcy.Core.props`

🤖 Generated with [Claude Code](https://claude.com/claude-code)