### PR TITLE
Add diagnostic error reporting for silent failures

### DIFF
--- a/Sourcy.Git/GitSourceGenerator.cs
+++ b/Sourcy.Git/GitSourceGenerator.cs
@@ -133,9 +133,10 @@ internal class GitSourceGenerator : BaseSourcyGenerator
                 context.ReportShallowClone();
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Ignore errors - shallow clone detection is informational only
+            // Shallow clone detection is informational - report as unexpected error for edge case debugging
+            context.ReportUnexpectedError("CheckShallowClone", ex);
         }
     }
 
@@ -154,9 +155,10 @@ internal class GitSourceGenerator : BaseSourcyGenerator
                 context.ReportSubmoduleDetected(PathUtilities.NormalizeGitPath(superproject));
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Ignore errors - submodule detection is informational only
+            // Submodule detection is informational - report as unexpected error for edge case debugging
+            context.ReportUnexpectedError("CheckSubmodule", ex);
         }
     }
 

--- a/Sourcy/BaseSourcyGenerator.cs
+++ b/Sourcy/BaseSourcyGenerator.cs
@@ -50,6 +50,7 @@ public abstract class BaseSourcyGenerator : IIncrementalGenerator
                 if (options.ProjectDir is null)
                 {
                     Debug.WriteLine("No Sourcy Directory found.");
+                    productionContext.ReportNoProjectDir();
                     return;
                 }
 

--- a/Sourcy/SourcyDiagnostics.cs
+++ b/Sourcy/SourcyDiagnostics.cs
@@ -34,6 +34,8 @@ internal static class SourcyDiagnostics
     private const string MaxDepthReachedId = "SOURCY012";
     private const string RelativePathFallbackId = "SOURCY013";
     private const string CloudPlaceholderId = "SOURCY014";
+    private const string UnexpectedErrorId = "SOURCY015";
+    private const string NoProjectDirId = "SOURCY016";
 
     // Diagnostic Descriptors
     public static readonly DiagnosticDescriptor RootNotFound = new(
@@ -236,6 +238,26 @@ internal static class SourcyDiagnostics
         description: "Cloud sync placeholder files are not downloaded locally and cannot be reliably accessed during build."
     );
 
+    public static readonly DiagnosticDescriptor UnexpectedError = new(
+        id: UnexpectedErrorId,
+        title: "Unexpected error during source generation",
+        messageFormat: "Sourcy encountered an unexpected error in {0}: {1}. Please report this issue at https://github.com/thomhurst/Sourcy/issues",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "An unexpected error occurred during source generation. This may indicate a bug in Sourcy or an edge case in your environment."
+    );
+
+    public static readonly DiagnosticDescriptor NoProjectDir = new(
+        id: NoProjectDirId,
+        title: "Project directory not available",
+        messageFormat: "The project directory could not be determined. Ensure build_property.ProjectDir is set. This may occur in unusual build configurations.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Sourcy could not determine the project directory, which is required to locate the repository root."
+    );
+
     // Helper methods for reporting diagnostics
     public static void ReportRootNotFound(this SourceProductionContext context)
     {
@@ -335,5 +357,15 @@ internal static class SourcyDiagnostics
     public static void ReportCloudPlaceholder(this SourceProductionContext context, string path)
     {
         context.ReportDiagnostic(Diagnostic.Create(CloudPlaceholder, Location.None, path));
+    }
+
+    public static void ReportUnexpectedError(this SourceProductionContext context, string location, Exception exception)
+    {
+        context.ReportDiagnostic(Diagnostic.Create(UnexpectedError, Location.None, location, $"{exception.GetType().Name}: {exception.Message}"));
+    }
+
+    public static void ReportNoProjectDir(this SourceProductionContext context)
+    {
+        context.ReportDiagnostic(Diagnostic.Create(NoProjectDir, Location.None));
     }
 }


### PR DESCRIPTION
## Summary
- Adds two new diagnostic warnings (`SOURCY015` and `SOURCY016`) to surface errors that were previously swallowed silently
- Previously silent catch blocks in `CheckShallowClone()` and `CheckSubmodule()` now report unexpected errors with full exception details
- When `build_property.ProjectDir` is unavailable, users now see a clear warning explaining why generation didn't happen

This enables users to understand edge case failures and report bugs with specific error information.

## New Diagnostics

| ID | Title | Severity | Description |
|----|-------|----------|-------------|
| SOURCY015 | Unexpected error during source generation | Warning | Reports unexpected exceptions with type, message, and link to report issues |
| SOURCY016 | Project directory not available | Warning | Reports when ProjectDir cannot be determined |

## Test plan
- [x] Build succeeds with no errors
- [x] All 22 existing tests pass
- [ ] Manually verify diagnostics appear in build output for edge cases (e.g., missing git, restricted directories)