### PR TITLE
Improve code quality and fix pipeline parsing error

### DIFF
--- a/Sourcy.Core/Sourcy.Core.csproj
+++ b/Sourcy.Core/Sourcy.Core.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <RootNamespace>Sourcy</RootNamespace>
         <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <!-- Include props file in NuGet package for MSBuild-based root detection -->

--- a/Sourcy.Docker/DockerSourceGenerator.cs
+++ b/Sourcy.Docker/DockerSourceGenerator.cs
@@ -33,6 +33,7 @@ internal class DockerSourceGenerator : BaseSourcyGenerator
 
         sourceBuilder.AppendLine("namespace Sourcy.Docker;");
         sourceBuilder.AppendLine();
+        sourceBuilder.AppendLine("[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Sourcy.Docker\", \"1.0.0\")]");
         sourceBuilder.AppendLine("internal static class Dockerfiles");
         sourceBuilder.AppendLine("{");
 
@@ -44,7 +45,7 @@ internal class DockerSourceGenerator : BaseSourcyGenerator
                     dockerfile.Directory!.Name,
                     usedIdentifiers);
 
-                var escapedPath = PathEscaper.EscapeForVerbatimString(dockerfile.FullName);
+                var escapedPath = PathUtilities.EscapeForVerbatimString(dockerfile.FullName);
                 sourceBuilder.AppendLine($"\tpublic static global::System.IO.FileInfo {formattedName} {{ get; }} = new global::System.IO.FileInfo(@\"{escapedPath}\");");
             }
             catch (Exception ex)

--- a/Sourcy.DotNet/DotNetSourceGenerator.cs
+++ b/Sourcy.DotNet/DotNetSourceGenerator.cs
@@ -47,18 +47,19 @@ internal class DotNetSourceGenerator : BaseSourcyGenerator
         }
     }
 
-    private void WriteProjects(SourceProductionContext context, IEnumerable<SourceGeneratedPath> projects)
+    private static void WriteProjects(SourceProductionContext context, IEnumerable<SourceGeneratedPath> projects)
     {
         var sourceBuilder = new StringBuilder();
 
         sourceBuilder.AppendLine("namespace Sourcy.DotNet;");
         sourceBuilder.AppendLine();
+        sourceBuilder.AppendLine("[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Sourcy.DotNet\", \"1.0.0\")]");
         sourceBuilder.AppendLine("internal static class Projects");
         sourceBuilder.AppendLine("{");
 
         foreach (var project in projects)
         {
-            var escapedPath = PathEscaper.EscapeForVerbatimString(project.File.FullName);
+            var escapedPath = PathUtilities.EscapeForVerbatimString(project.File.FullName);
             sourceBuilder.AppendLine($"\tpublic static global::System.IO.FileInfo {project.Name} {{ get; }} = new global::System.IO.FileInfo(@\"{escapedPath}\");");
         }
 
@@ -67,18 +68,19 @@ internal class DotNetSourceGenerator : BaseSourcyGenerator
         context.AddSource("DotNetProjectExtensions.g.cs", GetSourceText(sourceBuilder.ToString()));
     }
 
-    private void WriteSolutions(SourceProductionContext context, IEnumerable<SourceGeneratedPath> solutions)
+    private static void WriteSolutions(SourceProductionContext context, IEnumerable<SourceGeneratedPath> solutions)
     {
         var sourceBuilder = new StringBuilder();
 
         sourceBuilder.AppendLine("namespace Sourcy.DotNet;");
         sourceBuilder.AppendLine();
+        sourceBuilder.AppendLine("[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Sourcy.DotNet\", \"1.0.0\")]");
         sourceBuilder.AppendLine("internal static class Solutions");
         sourceBuilder.AppendLine("{");
 
         foreach (var solution in solutions)
         {
-            var escapedPath = PathEscaper.EscapeForVerbatimString(solution.File.FullName);
+            var escapedPath = PathUtilities.EscapeForVerbatimString(solution.File.FullName);
             sourceBuilder.AppendLine($"\tpublic static global::System.IO.FileInfo {solution.Name} {{ get; }} = new global::System.IO.FileInfo(@\"{escapedPath}\");");
         }
 

--- a/Sourcy.Pipeline/Modules/PackagePathsParserModule.cs
+++ b/Sourcy.Pipeline/Modules/PackagePathsParserModule.cs
@@ -12,11 +12,15 @@ public class PackagePathsParserModule : Module<List<File>>
     {
         var packPackagesModuleResult = await GetModule<PackProjectsModule>();
 
+        const string packageMarker = "Successfully created package '";
+
         return packPackagesModuleResult.Value!
-            .Select(x => x.StandardOutput)
-            .Select(x => x.Split("Successfully created package '")[1])
-            .Select(x => x.Split("'.")[0])
-            .Select(x => new File(x))
+            .SelectMany(x => x.StandardOutput.Split('\n'))
+            .Select(line => line.Trim())
+            .Where(line => line.Contains(packageMarker))
+            .Select(line => line.Split(packageMarker)[1])
+            .Select(path => path.TrimEnd('\'', '.'))
+            .Select(path => new File(path))
             .ToList();
     }
 }

--- a/Sourcy.Shared/BaseSourcyGenerator.cs
+++ b/Sourcy.Shared/BaseSourcyGenerator.cs
@@ -152,15 +152,16 @@ public abstract class BaseSourcyGenerator : IIncrementalGenerator
         }
 
         // Check cache first to avoid repeated file system traversals
-        if (RootCache.TryGetValue(path, out var cachedRoot))
+        // path is guaranteed non-null at this point due to the check above
+        if (RootCache.TryGetValue(path!, out var cachedRoot))
         {
             return cachedRoot;
         }
 
-        var root = GetRootDirectoryCore(path);
+        var root = GetRootDirectoryCore(path!);
 
         // Cache the result (including null results to avoid repeated failed lookups)
-        RootCache.TryAdd(path, root);
+        RootCache.TryAdd(path!, root);
 
         return root;
     }

--- a/Sourcy.Shared/PathUtilities.cs
+++ b/Sourcy.Shared/PathUtilities.cs
@@ -112,12 +112,3 @@ internal static class PathUtilities
         return path.StartsWith(prefix, PathComparison);
     }
 }
-
-/// <summary>
-/// Alias for backward compatibility - redirects to PathUtilities.
-/// </summary>
-internal static class PathEscaper
-{
-    public static string EscapeForVerbatimString(string path) => PathUtilities.EscapeForVerbatimString(path);
-    public static string EscapeForStringLiteral(string value) => PathUtilities.EscapeForStringLiteral(value);
-}

--- a/Sourcy.Shared/Root.cs
+++ b/Sourcy.Shared/Root.cs
@@ -7,8 +7,11 @@ using System.IO;
 
 namespace Sourcy;
 
-[DebuggerDisplay("{Directory,nq}")]
-public record Root(DirectoryInfo Directory) : IEqualityComparer<Root>
+/// <summary>
+/// Represents the root directory of a repository for source generation.
+/// </summary>
+[DebuggerDisplay("{Directory.FullName,nq}")]
+public sealed record Root(DirectoryInfo Directory) : IEquatable<Root>
 {
     public IEnumerable<FileInfo> EnumerateFiles(SkippedPathCallback? onSkipped = null)
     {
@@ -86,33 +89,29 @@ public record Root(DirectoryInfo Directory) : IEqualityComparer<Root>
         return Path.GetFileName(filePath);
     }
 
-    public bool Equals(Root? x, Root? y)
+    /// <summary>
+    /// Determines equality based on the directory's full path using platform-appropriate case sensitivity.
+    /// </summary>
+    public bool Equals(Root? other)
     {
-        if (ReferenceEquals(x, y))
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
         {
             return true;
         }
 
-        if (x is null)
-        {
-            return false;
-        }
-
-        if (y is null)
-        {
-            return false;
-        }
-
-        if (x.GetType() != y.GetType())
-        {
-            return false;
-        }
-
-        return x.Directory.FullName.Equals(y.Directory.FullName);
+        return PathUtilities.PathEquals(Directory.FullName, other.Directory.FullName);
     }
 
-    public int GetHashCode(Root obj)
+    /// <summary>
+    /// Returns a hash code based on the directory's full path using platform-appropriate case sensitivity.
+    /// </summary>
+    public override int GetHashCode()
     {
-        return obj.Directory.GetHashCode();
+        return PathUtilities.PathComparer.GetHashCode(Directory.FullName);
     }
 }

--- a/Sourcy.Tests/DockerfileTests.cs
+++ b/Sourcy.Tests/DockerfileTests.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace Sourcy.Tests;
 
 public class DockerfileTests

--- a/Sourcy.Tests/DotNetTests.cs
+++ b/Sourcy.Tests/DotNetTests.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace Sourcy.Tests;
 
 public class DotNetTests

--- a/Sourcy.Tests/GeneratorEdgeCaseTests.cs
+++ b/Sourcy.Tests/GeneratorEdgeCaseTests.cs
@@ -1,0 +1,125 @@
+namespace Sourcy.Tests;
+
+/// <summary>
+/// Tests for edge cases and advanced scenarios in source generators.
+/// </summary>
+public class GeneratorEdgeCaseTests
+{
+    [Test]
+    public async Task Git_RootDirectory_IsNotNull()
+    {
+        await Assert.That(Git.RootDirectory).IsNotNull();
+    }
+
+    [Test]
+    public async Task Git_RootDirectory_Exists()
+    {
+        await Assert.That(Git.RootDirectory.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task Git_BranchName_IsNotEmpty()
+    {
+        await Assert.That(Git.BranchName).IsNotEmpty();
+    }
+
+    [Test]
+    public async Task DotNet_Projects_AllExist()
+    {
+        // Verify all generated project references point to existing files
+        var projects = new[]
+        {
+            DotNet.Projects.Sourcy,
+            DotNet.Projects.Sourcy_Core,
+            DotNet.Projects.Sourcy_DotNet,
+            DotNet.Projects.Sourcy_Docker,
+            DotNet.Projects.Sourcy_Git,
+            DotNet.Projects.Sourcy_Node,
+            DotNet.Projects.Sourcy_Pipeline,
+            DotNet.Projects.Sourcy_Tests,
+        };
+
+        foreach (var project in projects)
+        {
+            await Assert.That(project.Exists).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task DotNet_Projects_HaveCorrectExtensions()
+    {
+        var projects = new[]
+        {
+            DotNet.Projects.Sourcy,
+            DotNet.Projects.Sourcy_Core,
+            DotNet.Projects.Sourcy_DotNet,
+        };
+
+        foreach (var project in projects)
+        {
+            await Assert.That(project.Extension).IsEqualTo(".csproj");
+        }
+    }
+
+    [Test]
+    public async Task DotNet_Solutions_Exist()
+    {
+        await Assert.That(DotNet.Solutions.Sourcy.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task DotNet_Solutions_HaveCorrectExtension()
+    {
+        await Assert.That(DotNet.Solutions.Sourcy.Extension).IsEqualTo(".sln");
+    }
+
+    [Test]
+    public async Task Docker_Dockerfiles_Exist()
+    {
+        await Assert.That(Docker.Dockerfiles.MongoDB.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task Docker_Dockerfiles_HaveCorrectName()
+    {
+        await Assert.That(Docker.Dockerfiles.MongoDB.Name).IsEqualTo("Dockerfile");
+    }
+
+    [Test]
+    public async Task Git_RootDirectory_ContainsExpectedFiles()
+    {
+        var rootFiles = Git.RootDirectory.GetFiles("*.sln");
+
+        await Assert.That(rootFiles.Length).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Git_RootDirectory_ContainsExpectedDirectories()
+    {
+        var directories = Git.RootDirectory.GetDirectories();
+
+        await Assert.That(directories.Length).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task DotNet_Projects_CanBeReadAsFileInfo()
+    {
+        var project = DotNet.Projects.Sourcy;
+
+        // Verify FileInfo methods work correctly
+        await Assert.That(project.Name).IsNotEmpty();
+        await Assert.That(project.DirectoryName).IsNotNull();
+        await Assert.That(project.FullName).Contains("Sourcy");
+    }
+
+    [Test]
+    public async Task Git_BranchName_DoesNotContainInvalidCharacters()
+    {
+        var branchName = Git.BranchName;
+
+        // Branch names should not contain line breaks or null characters
+        await Assert.That(branchName).DoesNotContain("\n");
+        await Assert.That(branchName).DoesNotContain("\r");
+        await Assert.That(branchName).DoesNotContain("\0");
+    }
+}

--- a/Sourcy.Tests/GitTests.cs
+++ b/Sourcy.Tests/GitTests.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace Sourcy.Tests;
 
 public class GitTests

--- a/Sourcy.Tests/Sourcy.Tests.csproj
+++ b/Sourcy.Tests/Sourcy.Tests.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <RootNamespace>Sourcy.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Fix critical pipeline bug causing `IndexOutOfRangeException` in `PackagePathsParserModule`
- Apply code quality improvements across all source generators
- Add integration tests for edge cases

## Changes

### Bug Fix
- **PackagePathsParserModule**: Fixed parsing of `dotnet pack` output that was failing because it assumed single-line output when the actual output is multi-line

### Code Quality Improvements
- Enable nullable reference types in `Sourcy.Core`
- Fix cache key collision risk in `GitSourceGenerator` by using explicit string keys instead of hash codes
- Narrow Polly retry exception handling to specific types (`TimeoutException`, `IOException`, `InvalidOperationException`) instead of catching all exceptions
- Consolidate duplicate `WriteProjects` methods in `NodeSourceGenerator` into a single parameterized method
- Fix `Root` equality implementation to use `IEquatable<Root>` with platform-appropriate path comparison
- Add `GeneratedCodeAttribute` to all generated classes for tooling support
- Remove unused `PathEscaper` backward-compatibility alias
- Make methods static where appropriate in `DotNetSourceGenerator`
- Add `ImplicitUsings` to test project

### Tests
- Add new `GeneratorEdgeCaseTests` class with 13 integration tests covering edge cases

## Test plan
- [x] All 35 tests pass (24 in Sourcy.Tests + 11 in Sourcy.NuGet.Tests)
- [x] Build succeeds with 0 warnings, 0 errors
- [ ] Pipeline run succeeds on GitHub Actions