### PR TITLE
Improve SafeWalk robustness

### DIFF
--- a/Sourcy.Docker/DockerSourceGenerator.cs
+++ b/Sourcy.Docker/DockerSourceGenerator.cs
@@ -14,7 +14,7 @@ internal class DockerSourceGenerator : BaseSourcyGenerator
     {
         try
         {
-            var dockerfiles = root.EnumerateFiles()
+            var dockerfiles = EnumerateFiles(context, root)
                 .Where(x => x.Name is "Dockerfile")
                 .ToList();
 

--- a/Sourcy.DotNet/DotNetSourceGenerator.cs
+++ b/Sourcy.DotNet/DotNetSourceGenerator.cs
@@ -18,7 +18,7 @@ internal class DotNetSourceGenerator : BaseSourcyGenerator
 
         try
         {
-            foreach (var file in root.EnumerateFiles())
+            foreach (var file in EnumerateFiles(context, root))
             {
                 try
                 {

--- a/Sourcy.Node/NodeSourceGenerator.cs
+++ b/Sourcy.Node/NodeSourceGenerator.cs
@@ -14,22 +14,24 @@ internal class NodeSourceGenerator : BaseSourcyGenerator
     {
         try
         {
+            var files = EnumerateFiles(context, root).ToList();
+
             // Use path-based comparison for Distinct() since DirectoryInfo compares by reference
-            var npmProjects = root.EnumerateFiles()
+            var npmProjects = files
                 .Where(x => x.Name is "package-lock.json")
                 .Where(x => !IsInNodeModules(x))
                 .Select(x => x.Directory!)
                 .DistinctBy(x => x.FullName, PathUtilities.PathComparer)
                 .ToList();
 
-            var yarnProjects = root.EnumerateFiles()
+            var yarnProjects = files
                 .Where(x => x.Name is "yarn.lock")
                 .Where(x => !IsInNodeModules(x))
                 .Select(x => x.Directory!)
                 .DistinctBy(x => x.FullName, PathUtilities.PathComparer)
                 .ToList();
 
-            var pnpmProjects = root.EnumerateFiles()
+            var pnpmProjects = files
                 .Where(x => x.Name is "pnpm-lock.yaml")
                 .Where(x => !IsInNodeModules(x))
                 .Select(x => x.Directory!)

--- a/Sourcy.Shared/BaseSourcyGenerator.cs
+++ b/Sourcy.Shared/BaseSourcyGenerator.cs
@@ -350,6 +350,40 @@ public abstract class BaseSourcyGenerator : IIncrementalGenerator
     {
         return SourceText.From(code, Encoding.UTF8);
     }
+
+    protected static IEnumerable<FileInfo> EnumerateFiles(SourceProductionContext context, Root root)
+    {
+        return root.EnumerateFiles(skippedPath => ReportSkippedPath(context, skippedPath));
+    }
+
+    private static void ReportSkippedPath(SourceProductionContext context, SkippedPath skippedPath)
+    {
+        switch (skippedPath.Reason)
+        {
+            case SkipReason.UnauthorizedAccess:
+                context.ReportUnauthorizedAccess(skippedPath.Path);
+                break;
+            case SkipReason.PathTooLong:
+                context.ReportPathTooLong(skippedPath.Path);
+                break;
+            case SkipReason.SymlinkCycle when skippedPath.TargetPath != null:
+                context.ReportSymlinkCycle(skippedPath.Path, skippedPath.TargetPath);
+                break;
+            case SkipReason.MaxDepthReached when skippedPath.Depth.HasValue:
+                context.ReportMaxDepthReached(skippedPath.Path, skippedPath.Depth.Value);
+                break;
+            case SkipReason.CloudPlaceholder:
+                context.ReportCloudPlaceholder(skippedPath.Path);
+                break;
+            case SkipReason.ExcludedDirectory:
+            case SkipReason.HiddenOrSystem:
+            case SkipReason.DuplicateRealPath:
+                break;
+            default:
+                context.ReportFileSkipped(skippedPath.Path, skippedPath.Reason.ToString());
+                break;
+        }
+    }
     
     protected IEnumerable<SourceGeneratedPath> Distinct(Root root, List<FileInfo> files, SourceProductionContext? context = null)
     {

--- a/Sourcy.Shared/SafeWalk.cs
+++ b/Sourcy.Shared/SafeWalk.cs
@@ -19,6 +19,7 @@ public enum SkipReason
     IoError,
     SecurityException,
     SymlinkCycle,
+    DuplicateRealPath,
     MaxDepthReached,
     ExcludedDirectory,
     HiddenOrSystem,
@@ -97,13 +98,6 @@ internal static class SafeWalk
 
                 foreach (var file in files)
                 {
-                    // Skip cloud placeholder files (OneDrive, iCloud, Dropbox)
-                    if (IsCloudPlaceholder(file))
-                    {
-                        onSkipped?.Invoke(new SkippedPath(file.FullName, SkipReason.CloudPlaceholder));
-                        continue;
-                    }
-
                     yield return file;
                 }
             }
@@ -131,14 +125,16 @@ internal static class SafeWalk
 
     public static IEnumerable<DirectoryInfo> EnumerateDirectories(DirectoryInfo directory, SkippedPathCallback? onSkipped = null)
     {
-        // Use a visited set to detect symlink cycles with platform-appropriate case sensitivity
-        var visited = new HashSet<string>(PathUtilities.PathComparer);
-        return EnumerateDirectoriesInternal(directory, visited, 0, onSkipped);
+        // Use real paths to avoid cycles and duplicate traversal through symlinks/junctions.
+        var visitedRealPaths = new HashSet<string>(PathUtilities.PathComparer);
+        var activeRealPaths = new HashSet<string>(PathUtilities.PathComparer);
+        return EnumerateDirectoriesInternal(directory, visitedRealPaths, activeRealPaths, 0, onSkipped);
     }
 
     private static IEnumerable<DirectoryInfo> EnumerateDirectoriesInternal(
         DirectoryInfo directory,
-        HashSet<string> visited,
+        HashSet<string> visitedRealPaths,
+        HashSet<string> activeRealPaths,
         int depth,
         SkippedPathCallback? onSkipped)
     {
@@ -149,7 +145,7 @@ internal static class SafeWalk
             yield break;
         }
 
-        var (shouldSearch, skipReason) = ShouldSearchDirectoryWithReason(directory);
+        var (shouldSearch, skipReason) = ShouldSearchDirectoryWithReason(directory, isRoot: depth == 0);
         if (!shouldSearch)
         {
             if (skipReason.HasValue)
@@ -171,120 +167,88 @@ internal static class SafeWalk
             yield break;
         }
 
-        // Check for cycles (symlink pointing to parent directory)
-        if (!visited.Add(realPath))
+        if (!activeRealPaths.Add(realPath))
         {
             onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.SymlinkCycle, targetPath: realPath));
             yield break;
         }
 
-        yield return directory;
-
-        DirectoryInfo[]? subDirectories = null;
-
         try
         {
-            subDirectories = directory.GetDirectories("*", SearchOption.TopDirectoryOnly);
-        }
-        catch (UnauthorizedAccessException)
-        {
-            onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.UnauthorizedAccess));
-            yield break;
-        }
-        catch (DirectoryNotFoundException)
-        {
-            onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.DirectoryNotFound));
-            yield break;
-        }
-        catch (PathTooLongException)
-        {
-            onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.PathTooLong));
-            yield break;
-        }
-        catch (IOException)
-        {
-            onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.IoError));
-            yield break;
-        }
-        catch (System.Security.SecurityException)
-        {
-            onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.SecurityException));
-            yield break;
-        }
+            if (!visitedRealPaths.Add(realPath))
+            {
+                onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.DuplicateRealPath, targetPath: realPath));
+                yield break;
+            }
 
-        if (subDirectories == null)
-        {
-            yield break;
-        }
+            yield return directory;
 
-        // Sort directories for deterministic output across builds
-        Array.Sort(subDirectories, (a, b) => string.Compare(a.FullName, b.FullName, StringComparison.Ordinal));
-
-        foreach (var folder in subDirectories)
-        {
-            IEnumerable<DirectoryInfo>? innerFolders = null;
+            DirectoryInfo[]? subDirectories = null;
 
             try
             {
-                // Check if this is a symlink/junction - skip if it would cause a cycle
-                if (IsSymbolicLinkOrJunction(folder))
-                {
-                    var targetPath = GetRealPath(folder);
-                    if (visited.Contains(targetPath))
-                    {
-                        onSkipped?.Invoke(new SkippedPath(folder.FullName, SkipReason.SymlinkCycle, targetPath: targetPath));
-                        continue;
-                    }
-
-                    // Mark the symlink target as visited to avoid revisiting it via other symlinks
-                    visited.Add(targetPath);
-                }
-
-                innerFolders = EnumerateDirectoriesInternal(folder, visited, depth + 1, onSkipped);
+                subDirectories = directory.GetDirectories("*", SearchOption.TopDirectoryOnly);
             }
             catch (UnauthorizedAccessException)
             {
-                onSkipped?.Invoke(new SkippedPath(folder.FullName, SkipReason.UnauthorizedAccess));
-                continue;
+                onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.UnauthorizedAccess));
+                yield break;
             }
             catch (DirectoryNotFoundException)
             {
-                onSkipped?.Invoke(new SkippedPath(folder.FullName, SkipReason.DirectoryNotFound));
-                continue;
+                onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.DirectoryNotFound));
+                yield break;
             }
             catch (PathTooLongException)
             {
-                onSkipped?.Invoke(new SkippedPath(folder.FullName, SkipReason.PathTooLong));
-                continue;
+                onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.PathTooLong));
+                yield break;
             }
             catch (IOException)
             {
-                onSkipped?.Invoke(new SkippedPath(folder.FullName, SkipReason.IoError));
-                continue;
+                onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.IoError));
+                yield break;
             }
             catch (System.Security.SecurityException)
             {
-                onSkipped?.Invoke(new SkippedPath(folder.FullName, SkipReason.SecurityException));
-                continue;
+                onSkipped?.Invoke(new SkippedPath(directory.FullName, SkipReason.SecurityException));
+                yield break;
             }
 
-            if (innerFolders != null)
+            if (subDirectories == null)
             {
-                foreach (var innerFolder in innerFolders)
+                yield break;
+            }
+
+            // Sort directories for deterministic output and visit concrete directories before links.
+            Array.Sort(subDirectories, CompareDirectoriesForTraversal);
+
+            foreach (var folder in subDirectories)
+            {
+                foreach (var innerFolder in EnumerateDirectoriesInternal(
+                             folder,
+                             visitedRealPaths,
+                             activeRealPaths,
+                             depth + 1,
+                             onSkipped))
                 {
                     yield return innerFolder;
                 }
             }
         }
+        finally
+        {
+            activeRealPaths.Remove(realPath);
+        }
     }
 
     private static bool ShouldSearchDirectory(DirectoryInfo directory)
     {
-        var (shouldSearch, _) = ShouldSearchDirectoryWithReason(directory);
+        var (shouldSearch, _) = ShouldSearchDirectoryWithReason(directory, isRoot: false);
         return shouldSearch;
     }
 
-    private static (bool ShouldSearch, SkipReason? Reason) ShouldSearchDirectoryWithReason(DirectoryInfo directory)
+    private static (bool ShouldSearch, SkipReason? Reason) ShouldSearchDirectoryWithReason(DirectoryInfo directory, bool isRoot)
     {
         try
         {
@@ -296,14 +260,8 @@ internal static class SafeWalk
 
             var attributes = directory.Attributes;
 
-            // Skip hidden directories (but allow on Linux where .folders are common)
-            if ((attributes & FileAttributes.Hidden) != 0 && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return (false, SkipReason.HiddenOrSystem);
-            }
-
-            // Skip system directories
-            if ((attributes & FileAttributes.System) != 0)
+            // Skip system directories below the root. The root was explicitly selected by Sourcy.
+            if (!isRoot && (attributes & FileAttributes.System) != 0)
             {
                 return (false, SkipReason.HiddenOrSystem);
             }
@@ -345,7 +303,7 @@ internal static class SafeWalk
     {
         try
         {
-            var fullPath = directory.FullName;
+            var fullPath = NormalizePathForComparison(directory.FullName);
 
             // If this is a symlink/reparse point, try to resolve the target
             if (IsSymbolicLinkOrJunction(directory))
@@ -353,14 +311,8 @@ internal static class SafeWalk
                 var resolvedPath = ResolveSymlinkTarget(directory);
                 if (!string.IsNullOrEmpty(resolvedPath))
                 {
-                    fullPath = resolvedPath!;
+                    fullPath = NormalizePathForComparison(resolvedPath!);
                 }
-            }
-
-            // On case-insensitive platforms, normalize to lowercase for consistent comparison
-            if (!PathUtilities.IsCaseSensitive)
-            {
-                fullPath = fullPath.ToLowerInvariant();
             }
 
             return fullPath;
@@ -369,6 +321,56 @@ internal static class SafeWalk
         {
             return directory.FullName;
         }
+    }
+
+    private static int CompareDirectoriesForTraversal(DirectoryInfo left, DirectoryInfo right)
+    {
+        var leftIsLink = IsSymbolicLinkOrJunction(left);
+        var rightIsLink = IsSymbolicLinkOrJunction(right);
+
+        if (leftIsLink != rightIsLink)
+        {
+            return leftIsLink ? 1 : -1;
+        }
+
+        return string.Compare(left.FullName, right.FullName, StringComparison.Ordinal);
+    }
+
+    private static string NormalizePathForComparison(string path)
+    {
+        try
+        {
+            path = Path.GetFullPath(path);
+        }
+        catch
+        {
+            // Use the original string if the platform cannot normalize it.
+        }
+
+        return TrimEndingDirectorySeparator(path);
+    }
+
+    private static string TrimEndingDirectorySeparator(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        var root = Path.GetPathRoot(path);
+        var rootLength = root?.Length ?? 0;
+
+        while (path.Length > rootLength && IsDirectorySeparator(path[path.Length - 1]))
+        {
+            path = path.Substring(0, path.Length - 1);
+        }
+
+        return path;
+    }
+
+    private static bool IsDirectorySeparator(char value)
+    {
+        return value == Path.DirectorySeparatorChar || value == Path.AltDirectorySeparatorChar;
     }
 
     /// <summary>
@@ -487,39 +489,4 @@ internal static class SafeWalk
         }
     }
 
-    /// <summary>
-    /// Checks if a file is a cloud placeholder (OneDrive, iCloud, Dropbox, etc.).
-    /// Cloud placeholders are files that exist in the cloud but aren't downloaded locally.
-    /// Accessing them can trigger downloads or fail unexpectedly.
-    /// </summary>
-    private static bool IsCloudPlaceholder(FileInfo file)
-    {
-        try
-        {
-            var attributes = file.Attributes;
-
-            // FileAttributes.Offline indicates the file data is not immediately available
-            // This is commonly used by cloud sync providers for placeholder files
-            if ((attributes & FileAttributes.Offline) != 0)
-            {
-                return true;
-            }
-
-            // ReparsePoint can indicate cloud placeholders on Windows (OneDrive, etc.)
-            // Combined with SparseFile, this often indicates a cloud placeholder
-            if ((attributes & FileAttributes.ReparsePoint) != 0 &&
-                (attributes & FileAttributes.SparseFile) != 0)
-            {
-                return true;
-            }
-
-            return false;
-        }
-        catch
-        {
-            // If we can't read attributes, assume it's not a placeholder
-            // The file might fail later but we'll handle that separately
-            return false;
-        }
-    }
 }

--- a/Sourcy.Tests/SafeWalkTests.cs
+++ b/Sourcy.Tests/SafeWalkTests.cs
@@ -1,0 +1,159 @@
+namespace Sourcy.Tests;
+
+public class SafeWalkTests
+{
+    private static readonly Lazy<System.Reflection.Assembly> GeneratorAssembly = new(LoadGeneratorAssembly);
+
+    [Test]
+    public async Task EnumerateFiles_Includes_Files_In_Hidden_Directories()
+    {
+        var testRoot = CreateTestDirectory();
+
+        try
+        {
+            var hiddenDirectory = Directory.CreateDirectory(Path.Combine(testRoot, "hidden"));
+            hiddenDirectory.Attributes |= FileAttributes.Hidden;
+
+            var projectPath = Path.Combine(hiddenDirectory.FullName, "Hidden.csproj");
+            await File.WriteAllTextAsync(projectPath, string.Empty);
+
+            var files = EnumerateFiles(new DirectoryInfo(testRoot));
+
+            await Assert.That(files.Any(x => x.FullName == projectPath)).IsTrue();
+        }
+        finally
+        {
+            ResetAttributesAndDelete(testRoot);
+        }
+    }
+
+    [Test]
+    public async Task EnumerateFiles_Does_Not_Treat_NonCyclic_Directory_Links_As_Cycles()
+    {
+        var testRoot = CreateTestDirectory();
+
+        try
+        {
+            var rootDirectory = Directory.CreateDirectory(Path.Combine(testRoot, "root"));
+            var targetDirectory = Directory.CreateDirectory(Path.Combine(testRoot, "target"));
+            var projectPath = Path.Combine(targetDirectory.FullName, "Linked.csproj");
+            await File.WriteAllTextAsync(projectPath, string.Empty);
+
+            var linkPath = Path.Combine(rootDirectory.FullName, "linked");
+            if (!TryCreateDirectoryLink(linkPath, targetDirectory.FullName))
+            {
+                return;
+            }
+
+            var files = EnumerateFiles(rootDirectory);
+
+            await Assert.That(files.Any(x => x.Name == "Linked.csproj")).IsTrue();
+        }
+        finally
+        {
+            ResetAttributesAndDelete(testRoot);
+        }
+    }
+
+    private static List<FileInfo> EnumerateFiles(DirectoryInfo directory)
+    {
+        var safeWalkType = GeneratorAssembly.Value.GetType("Sourcy.SafeWalk", throwOnError: true)!;
+        var enumerateFiles = safeWalkType.GetMethod(
+            "EnumerateFiles",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
+
+        var result = enumerateFiles.Invoke(null, new object?[] { directory, null });
+        return ((IEnumerable<FileInfo>) result!).ToList();
+    }
+
+    private static System.Reflection.Assembly LoadGeneratorAssembly()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var configuration = new DirectoryInfo(AppContext.BaseDirectory).Parent?.Name ?? "Debug";
+        var expectedPath = Path.Combine(
+            repositoryRoot,
+            "Sourcy.DotNet",
+            "bin",
+            configuration,
+            "netstandard2.0",
+            "Sourcy.DotNet.dll");
+
+        if (File.Exists(expectedPath))
+        {
+            return System.Reflection.Assembly.LoadFrom(expectedPath);
+        }
+
+        var binPath = Path.Combine(repositoryRoot, "Sourcy.DotNet", "bin");
+        var fallbackPath = Directory.Exists(binPath)
+            ? Directory.GetFiles(binPath, "Sourcy.DotNet.dll", SearchOption.AllDirectories)
+                .OrderByDescending(File.GetLastWriteTimeUtc)
+                .FirstOrDefault()
+            : null;
+
+        if (fallbackPath is null)
+        {
+            throw new FileNotFoundException("Could not locate built Sourcy.DotNet.dll for SafeWalk tests.", expectedPath);
+        }
+
+        return System.Reflection.Assembly.LoadFrom(fallbackPath);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Sourcy.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test output directory.");
+    }
+
+    private static string CreateTestDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "Sourcy.SafeWalk.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static bool TryCreateDirectoryLink(string linkPath, string targetPath)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, targetPath);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static void ResetAttributesAndDelete(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        foreach (var directory in Directory.GetDirectories(path, "*", SearchOption.AllDirectories))
+        {
+            try
+            {
+                File.SetAttributes(directory, FileAttributes.Normal);
+            }
+            catch
+            {
+                // Best effort cleanup for hidden directories.
+            }
+        }
+
+        Directory.Delete(path, recursive: true);
+    }
+}


### PR DESCRIPTION
## Summary
- make SafeWalk less machine-sensitive by including hidden directories and cloud placeholder file paths
- fix symlink/junction traversal so non-cyclic linked directories are not falsely skipped as cycles
- route SafeWalk skipped-path callbacks through generator diagnostics for DotNet, Docker, and Node generators
- add regression tests for hidden directories and non-cyclic directory links

## Verification
- `dotnet restore Sourcy.Tests\Sourcy.Tests.csproj`
- `dotnet build Sourcy.Tests\Sourcy.Tests.csproj --no-restore -v:minimal`
- `dotnet test Sourcy.Tests\Sourcy.Tests.csproj --no-build -v:minimal`